### PR TITLE
Adapt to latest Theia version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,25 +13,25 @@ on:
 
 jobs:
   build:
-    name: ubuntu-latest,  Node.js 16.x
+    name: ubuntu-latest,  Node.js 18.x
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Use Node.js "16.x"
-        uses: actions/setup-node@v1
+      - name: Use Node.js "18.x"
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Use Python 3.x
-        uses: actions/setup-python@v2
+      - name: Use Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.11"
 
       - name: Build
         shell: bash
@@ -39,24 +39,23 @@ jobs:
           yarn
 
       - name: Checkout Theia
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: eclipse-theia/theia
           path: ./theia
 
-      - name: Build Theia
+      - name: Build Theia browser example
         shell: bash
         working-directory: ./theia
         run: |
           yarn --skip-integrity-check --network-timeout 100000
           yarn browser build
 
-      - name: Run Theia
+      - name: Run Theia browser example
         shell: bash
         working-directory: ./theia
         run: yarn browser start &
 
       - name: Test (playwright)
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: yarn ui-tests
+        shell: bash
+        run: yarn ui-tests

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "ui-tests-report": "yarn ui-tests-report-generate && allure open allure-results/allure-report"
   },
   "dependencies": {
-    "@playwright/test": "^1.32.1",
-    "@theia/playwright": "next"
+    "@playwright/test": "^1.42.1",
+    "@theia/playwright": "1.47.1"
   },
   "devDependencies": {
     "@typescript-eslint/parser": "^5.57.1",

--- a/tests/theia-app.test.ts
+++ b/tests/theia-app.test.ts
@@ -13,15 +13,18 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { MyTheiaApp } from './page-objects/theia-app';
+import { TheiaAppLoader } from '@theia/playwright';
 
-let page: Page;
 let app: MyTheiaApp;
 
-test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    app = await MyTheiaApp.loadApp(page, MyTheiaApp);
+test.beforeAll(async ({ playwright, browser }) => {
+    app = await TheiaAppLoader.load(
+        { playwright, browser },
+        undefined,
+        MyTheiaApp
+    );
 });
 
 test.describe('My Theia application', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,22 +74,19 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/test@^1.32.1":
-  version "1.32.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.32.2.tgz#3cbd76b3f94d0f7f50bf054dbd02e504e85e3865"
-  integrity sha512-nhaTSDpEdTTttdkDE8Z6K3icuG1DVRxrl98Qq0Lfc63SS9a2sjc9+x8ezysh7MzCKz6Y+nArml3/mmt+gqRmQQ==
+"@playwright/test@^1.37.1", "@playwright/test@^1.42.1":
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.42.1.tgz#9eff7417bcaa770e9e9a00439e078284b301f31c"
+  integrity sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.32.2"
-  optionalDependencies:
-    fsevents "2.3.2"
+    playwright "1.42.1"
 
-"@theia/playwright@next":
-  version "1.37.0-next.9"
-  resolved "https://registry.yarnpkg.com/@theia/playwright/-/playwright-1.37.0-next.9.tgz#8f1b24b579cb401fd97f1d1e2286f06a5b895753"
-  integrity sha512-GHQgw0Y+5Gqyfum+tintWSArkv/bQFb9d5PE+gAfY1i3ps5S3j1oifyckve1guNfz6DPSP3gzQD8PewwVDZ4+w==
+"@theia/playwright@1.47.1":
+  version "1.47.1"
+  resolved "https://registry.yarnpkg.com/@theia/playwright/-/playwright-1.47.1.tgz#d053d3309bf5b520d92d718c665c417f57ac8e84"
+  integrity sha512-JJS1BF+dZFaiVhgRlAmzPFQ2euIUH/dSXiL5fFH0LvwO+WkdUJf3rw46VJhQFKHkNf/Fv/wxenKRGb1UDgtdcw==
   dependencies:
-    "@playwright/test" "^1.32.1"
+    "@playwright/test" "^1.37.1"
     fs-extra "^9.0.8"
 
 "@types/json-schema@^7.0.9":
@@ -101,11 +98,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/node@*":
-  version "17.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
-  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
 
 "@types/semver@^7.3.12":
   version "7.3.13"
@@ -1259,10 +1251,19 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-playwright-core@1.32.2:
-  version "1.32.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.2.tgz#608810c3c4486fb86a224732ac0d3560a96ded8b"
-  integrity sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==
+playwright-core@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.42.1.tgz#13c150b93c940a3280ab1d3fbc945bc855c9459e"
+  integrity sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==
+
+playwright@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.42.1.tgz#79c828b51fe3830211137550542426111dc8239f"
+  integrity sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==
+  dependencies:
+    playwright-core "1.42.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Following this recent Theia commit [1], one now has to use "TheiaAppLoader.load()", to load a Theia application in a theia playwright templace. Some code here needs to be updated.

Also, use the latest versions (as of now) for @theia/playwright and @playwright/test

[1]: "Basic playwright electron support (#12207)"
https://github.com/eclipse-theia/theia/commit/487e92be7bba38e56ba63c872efa55cc6aee49e3